### PR TITLE
 fix: fix config

### DIFF
--- a/connector/config.go
+++ b/connector/config.go
@@ -50,7 +50,7 @@ func initConnectorConfig() (*Config, error) {
 	configFile := os.Getenv(configFileEnv)
 	if configFile == "" {
 		// default path
-		configFile = "./config.json"
+		configFile = "./config.yaml"
 	}
 
 	if err := cdkutil.ParseConfig(os.Getenv(configFileEnv), cfg); err != nil {

--- a/connector/config.go
+++ b/connector/config.go
@@ -18,9 +18,10 @@ package connector
 
 import (
 	"fmt"
-	cdkutil "github.com/linkall-labs/cdk-go/utils"
 	"os"
 	"strconv"
+
+	cdkutil "github.com/linkall-labs/cdk-go/utils"
 )
 
 type StateStore string
@@ -46,23 +47,32 @@ type Config struct {
 
 func initConnectorConfig() (*Config, error) {
 	cfg := &Config{}
+	configFile := os.Getenv(configFileEnv)
+	if configFile == "" {
+		// default path
+		configFile = "./config.json"
+	}
+
 	if err := cdkutil.ParseConfig(os.Getenv(configFileEnv), cfg); err != nil {
 		return nil, err
 	}
 
 	if cfg.Target == "" {
 		cfg.Target = os.Getenv(targetEndpointEnv)
-		if cfg.Target == "" {
-			return nil, fmt.Errorf("the v_target can't be empty")
-		}
 	}
 
 	if cfg.Port <= 0 {
-		p, err := strconv.ParseInt(os.Getenv(portEnv), 10, 16)
-		if err != nil {
-			return nil, fmt.Errorf("the v_port is empty or invalid")
+		portStr := os.Getenv(portEnv)
+		if portStr != "" {
+			p, err := strconv.ParseInt(portStr, 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("the v_port invalid")
+			}
+			cfg.Port = int(p)
+		} else {
+			// default port
+			cfg.Port = 8080
 		}
-		cfg.Port = int(p)
 	}
 	return cfg, nil
 }

--- a/connector/sink.go
+++ b/connector/sink.go
@@ -19,13 +19,13 @@ package connector
 import (
 	"context"
 	"fmt"
-	"github.com/cloudevents/sdk-go/v2/client"
-	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"net"
 	"os"
 
 	v2 "github.com/cloudevents/sdk-go/v2"
+	"github.com/cloudevents/sdk-go/v2/client"
 	"github.com/cloudevents/sdk-go/v2/protocol"
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
 	"github.com/linkall-labs/cdk-go/log"
 	cdkutil "github.com/linkall-labs/cdk-go/utils"
 )
@@ -36,7 +36,7 @@ type Sink interface {
 }
 
 func RunSink(sink Sink) {
-	logger := log.NewLogger()
+	logger := log.GetLogger()
 	logger.SetName(sink.Name())
 	sink.SetLogger(logger)
 	cfg, err := initConnectorConfig()

--- a/log/log.go
+++ b/log/log.go
@@ -62,8 +62,8 @@ func init() {
 
 var vLog Logger
 
-func NewLogger() Logger {
-	return &defaultLogger{}
+func GetLogger() Logger {
+	return vLog
 }
 
 type defaultLogger struct {

--- a/utils/config.go
+++ b/utils/config.go
@@ -25,7 +25,9 @@ import (
 
 func ParseConfig(file string, v interface{}) error {
 	data, err := os.ReadFile(file)
-
+	if err != nil {
+		return err
+	}
 	if strings.HasSuffix(file, "json") {
 		err = json.Unmarshal(data, v)
 	} else {


### PR DESCRIPTION
fix problem:

- when config file not exist, report  error "init global config file failed: the v_target can't be empty" 
- config v_target is not must need in sink
- config v_port is not must need in source
- fix log panic 